### PR TITLE
Expose HTTP server, allow triggering runs with a request to :8080/run

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,8 @@ func main() {
 	kingpin.Flag("log-level", "Set log level.").Envar("LOG_LEVEL").Default("info").StringVar(&flags.LogLevel)
 	kingpin.Flag("log-json", "Enable JSON logging output.").Envar("LOG_JSON").Default("false").BoolVar(&flags.LogJson)
 	kingpin.Flag("log-file", "Add logging to a specific file.").Envar("LOG_FILE").StringVar(&flags.LogFile)
+	kingpin.Flag("server", "Enable HTTP server for triggering on-demand runs.").Envar("SERVER").BoolVar(&flags.Server)
+	kingpin.Flag("server-port", "Port for HTTP server.").Envar("SERVER_PORT").Default("8080").StringVar(&flags.ServerPort)
 	kingpin.UsageTemplate(kingpin.CompactUsageTemplate).Version(version).Author("CrazyMax")
 	kingpin.CommandLine.Name = "ftpgrab"
 	kingpin.CommandLine.Help = `Grab your files periodically from a remote FTP or SFTP server easily. More info on https://ftpgrab.github.io`

--- a/internal/model/flags.go
+++ b/internal/model/flags.go
@@ -2,10 +2,12 @@ package model
 
 // Flags holds flags from command line
 type Flags struct {
-	Cfgfile  string
-	Schedule string
-	Timezone string
-	LogLevel string
-	LogJson  bool
-	LogFile  string
+	Cfgfile    string
+	Schedule   string
+	Timezone   string
+	LogLevel   string
+	LogJson    bool
+	LogFile    string
+	Server     bool
+	ServerPort string
 }


### PR DESCRIPTION
Sometimes I want to trigger an early run of ftpgrab. This feels like the easiest way to do that.

Two configuration options are added:

- `SERVER=true`: turn on the HTTP server
- `SERVER_PORT=8080`: change the server port (defaults to 8080)

With the server enabled, you can trigger a run with `curl http://localhost:8080/run`